### PR TITLE
correct: wrong sort order when dragging and dropping

### DIFF
--- a/frontend/src/app/project/components/board/board-dnd-list/board-dnd-list.component.ts
+++ b/frontend/src/app/project/components/board/board-dnd-list/board-dnd-list.component.ts
@@ -46,15 +46,10 @@ export class BoardDndListComponent implements OnInit {
       moveItemInArray(newIssues, event.previousIndex, event.currentIndex);
       this.updateListPosition(newIssues);
     } else {
-      transferArrayItem(
-        event.previousContainer.data,
-        newIssues,
-        event.previousIndex,
-        event.currentIndex
-      );
-      this.updateListPosition(newIssues);
+      transferArrayItem(event.previousContainer.data, event.container.data, event.previousIndex, event.currentIndex);
       newIssue.status = event.container.id as IssueStatus;
-      this._projectService.updateIssue(newIssue);
+      newIssues.splice(event.currentIndex, 0, newIssue);
+      this.updateListPosition(newIssues);
     }
   }
 


### PR DESCRIPTION
Hi Trung,

### PR Type

- [x] Feature
- [ ] Other

### What is the current behavior?

- Wrong sort order when dragging and dropping issue card on kanban board

### What is the new behavior?

- Correct sort order when dragging and dropping issue card on kanban board

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No